### PR TITLE
misc.c: variadic params for cpuid command on x86 only

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -258,7 +258,10 @@ runon(int argc, const char *argv[], const struct cmd_info *info)
 	return -1;
 }
 
+#ifdef ARCH_X86
 MAKE_PREREQ_PARAMS_VAR_ARGS(cpuid_params, 3, 4, "<cpu> <function> [index]", 0);
+#endif /* ARCH_X86 */
+
 MAKE_PREREQ_PARAMS_VAR_ARGS(runon_params, 3, INT_MAX, "<cpu> <cmd> [args]", 0);
 
 static const struct cmd_info misc_cmds[] = {


### PR DESCRIPTION
As the cpuid command is only compiled on x86, make the creation of variadic
parameters structure also x86-specific. This prevents the warning for unused
variable `cpuid_params` (which gets escalated to an error due to `-Werror`).

Signed-off-by: Jan Samek <samekh@email.cz>