### PR TITLE
scom: Fix access to lseek64()

### DIFF
--- a/scom.c
+++ b/scom.c
@@ -21,7 +21,7 @@
 /*
  * Quick POWER CPU SCOM register access, requires linux SCOM debugfs support.
  */
-#define _FILE_OFFSET_BITS 64
+#define _LARGEFILE64_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -65,7 +65,7 @@ open_and_seek(int chip, uint64_t scom, int mode, int *fd)
 		return -1;
 	}
 
-	if (lseek64(*fd, offset, SEEK_SET) == (off_t)-1) {
+	if (lseek64(*fd, offset, SEEK_SET) == (off64_t)-1) {
 		fprintf(stderr, "lseek(%jd): %s\n", offset, strerror(errno));
 		close(*fd);
 		return -1;


### PR DESCRIPTION
A build error, see #10, occurs when building for 64-bit PowerPC with musl libc. Since we explicitly use the 64-bit lseek64() API, we can simply replace the `_FILE_OFFSET_BITS` define (i.e. make `off_t` 64-bits) with `_LARGEFILE64_SOURCE` (i.e. make 64-bit API available).