### PR TITLE
CMakeLists.txt: remove an obsolete policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Enable -rdynamic link flag only if ENABLE_EXPORTS is True
-cmake_policy(SET CMP0065 NEW)
-
 project(iotools
 	VERSION 1.8
 	LANGUAGES C)


### PR DESCRIPTION
CMP0065 was introduced in CMake 3.4. Hence, it is already enabled through `cmake_minimum_required(VERSION 3.16)`.